### PR TITLE
Update WacAllowParser-test.js

### DIFF
--- a/__tests__/WacAllowParser-test.js
+++ b/__tests__/WacAllowParser-test.js
@@ -56,6 +56,20 @@ describe('WacAllowParser', () => {
           public: new Set(),
         });
       });
+      
+      test('parses permissions without quotes separated by commas', () => {
+        expect(parser.parseString('user=read, write, append')).toEqual({
+          user: new Set(['read', 'write', 'append']),
+          public: new Set(),
+        });
+      });
+      
+      test('parses permissions without quotes separated by commas without spaces', () => {
+        expect(parser.parseString('user=read,write,append')).toEqual({
+          user: new Set(['read', 'write', 'append']),
+          public: new Set(),
+        });
+      });
 
       test('parses two users with multiple permissions', () => {
         expect(parser.parseString('user="read write append",public="read append"')).toEqual({


### PR DESCRIPTION
Added tests for strings without quotes separated by commas with and without spaces.

It looks like from the regex in WacAllowParser.js that strings without quotes are already handled if they are separated by spaces, just not if they're separated by commas.  There is already a test for strings without quotes separated by spaces.